### PR TITLE
Fix: ConnectionProviders do not decrypt values

### DIFF
--- a/jasypt-hibernate5/src/main/java/org/jasypt/hibernate5/connectionprovider/EncryptedPasswordC3P0ConnectionProvider.java
+++ b/jasypt-hibernate5/src/main/java/org/jasypt/hibernate5/connectionprovider/EncryptedPasswordC3P0ConnectionProvider.java
@@ -19,6 +19,7 @@
  */
 package org.jasypt.hibernate5.connectionprovider;
 
+import java.util.Map;
 import java.util.Properties;
 
 import org.hibernate.c3p0.internal.C3P0ConnectionProvider;
@@ -94,12 +95,20 @@ public final class EncryptedPasswordC3P0ConnectionProvider
     public EncryptedPasswordC3P0ConnectionProvider() {
         super();
     }
-    
-    
+
+
+    @SuppressWarnings({"rawtypes"})
     public void configure(final Properties props) {
+        configure((Map) props);
+    }
+    
+    
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void configure(final Map props) {
        
        final String encryptorRegisteredName = 
-           props.getProperty(ParameterNaming.ENCRYPTOR_REGISTERED_NAME);
+           (String) props.get(ParameterNaming.ENCRYPTOR_REGISTERED_NAME);
        
        final HibernatePBEEncryptorRegistry encryptorRegistry =
            HibernatePBEEncryptorRegistry.getInstance();
@@ -113,29 +122,29 @@ public final class EncryptedPasswordC3P0ConnectionProvider
        }
 
        // Get the original values, which may be encrypted
-       final String driver = props.getProperty(AvailableSettings.DRIVER);
-       final String url = props.getProperty(AvailableSettings.URL);
-       final String user = props.getProperty(AvailableSettings.USER);
-       final String password = props.getProperty(AvailableSettings.PASS);
+       final String driver = (String) props.get(AvailableSettings.DRIVER);
+       final String url = (String) props.get(AvailableSettings.URL);
+       final String user = (String) props.get(AvailableSettings.USER);
+       final String password = (String) props.get(AvailableSettings.PASS);
 
        // Perform decryption operations as needed and store the new values
        if (PropertyValueEncryptionUtils.isEncryptedValue(driver)) {
-           props.setProperty(
+           props.put(
                    AvailableSettings.DRIVER, 
                    PropertyValueEncryptionUtils.decrypt(driver, encryptor));
        }
        if (PropertyValueEncryptionUtils.isEncryptedValue(url)) {
-           props.setProperty(
+           props.put(
                    AvailableSettings.URL, 
                    PropertyValueEncryptionUtils.decrypt(url, encryptor));
        }
        if (PropertyValueEncryptionUtils.isEncryptedValue(user)) {
-           props.setProperty(
+           props.put(
                    AvailableSettings.USER, 
                    PropertyValueEncryptionUtils.decrypt(user, encryptor));
        }
        if (PropertyValueEncryptionUtils.isEncryptedValue(password)) {
-           props.setProperty(
+           props.put(
                    AvailableSettings.PASS, 
                    PropertyValueEncryptionUtils.decrypt(password, encryptor));
        }

--- a/jasypt-hibernate5/src/main/java/org/jasypt/hibernate5/connectionprovider/EncryptedPasswordDriverManagerConnectionProvider.java
+++ b/jasypt-hibernate5/src/main/java/org/jasypt/hibernate5/connectionprovider/EncryptedPasswordDriverManagerConnectionProvider.java
@@ -19,6 +19,7 @@
  */
 package org.jasypt.hibernate5.connectionprovider;
 
+import java.util.Map;
 import java.util.Properties;
 
 import org.hibernate.cfg.AvailableSettings;
@@ -92,12 +93,20 @@ public final class EncryptedPasswordDriverManagerConnectionProvider
     public EncryptedPasswordDriverManagerConnectionProvider() {
         super();
     }
-    
-    
+
+
+    @SuppressWarnings({"rawtypes"})
     public void configure(final Properties props) {
+        configure((Map) props);
+    }
+    
+    
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void configure(final Map props) {
        
        final String encryptorRegisteredName = 
-           props.getProperty(ParameterNaming.ENCRYPTOR_REGISTERED_NAME);
+           (String) props.get(ParameterNaming.ENCRYPTOR_REGISTERED_NAME);
        
        final HibernatePBEEncryptorRegistry encryptorRegistry =
            HibernatePBEEncryptorRegistry.getInstance();
@@ -111,29 +120,29 @@ public final class EncryptedPasswordDriverManagerConnectionProvider
        }
 
        // Get the original values, which may be encrypted
-       final String driver = props.getProperty(AvailableSettings.DRIVER);
-       final String url = props.getProperty(AvailableSettings.URL);
-       final String user = props.getProperty(AvailableSettings.USER);
-       final String password = props.getProperty(AvailableSettings.PASS);
+       final String driver = (String) props.get(AvailableSettings.DRIVER);
+       final String url = (String) props.get(AvailableSettings.URL);
+       final String user = (String) props.get(AvailableSettings.USER);
+       final String password = (String) props.get(AvailableSettings.PASS);
 
        // Perform decryption operations as needed and store the new values
        if (PropertyValueEncryptionUtils.isEncryptedValue(driver)) {
-           props.setProperty(
+           props.put(
                    AvailableSettings.DRIVER, 
                    PropertyValueEncryptionUtils.decrypt(driver, encryptor));
        }
        if (PropertyValueEncryptionUtils.isEncryptedValue(url)) {
-           props.setProperty(
+           props.put(
                    AvailableSettings.URL, 
                    PropertyValueEncryptionUtils.decrypt(url, encryptor));
        }
        if (PropertyValueEncryptionUtils.isEncryptedValue(user)) {
-           props.setProperty(
+           props.put(
                    AvailableSettings.USER, 
                    PropertyValueEncryptionUtils.decrypt(user, encryptor));
        }
        if (PropertyValueEncryptionUtils.isEncryptedValue(password)) {
-           props.setProperty(
+           props.put(
                    AvailableSettings.PASS, 
                    PropertyValueEncryptionUtils.decrypt(password, encryptor));
        }


### PR DESCRIPTION
Hibernate's StandardServiceRegistryImpl.configureService(ServiceBinding) implementation calls Configurable.configure(Map) but jasypt-hibernate5's *ConnectionProviders do not override that method. The classes provide configure(Properties) method.